### PR TITLE
higher volume limits

### DIFF
--- a/prebuilt/system/etc/mixer_paths.xml
+++ b/prebuilt/system/etc/mixer_paths.xml
@@ -24,9 +24,9 @@
 	<ctl name="TTY Mode" value="Off" />
 	<ctl name="LINEOUT Volume" value="0" />
 	<ctl name="EAR PA Gain" value="POS_0_DB" />
-	<ctl name="RX1 Digital Volume" value="84" />
-	<ctl name="RX2 Digital Volume" value="84" />
-	<ctl name="RX3 Digital Volume" value="84" />
+	<ctl name="RX1 Digital Volume" value="90" />
+	<ctl name="RX2 Digital Volume" value="90" />
+	<ctl name="RX3 Digital Volume" value="90" />
 	<ctl name="IIR1 INP1 Volume" value="0" />
 	<ctl name="IIR1 INP2 Volume" value="0" />
 	<ctl name="IIR1 INP3 Volume" value="0" />


### PR DESCRIPTION
these volume limits help in proving better audio output/volume to headsets since they have larger audio drivers(speakers) and also improve performance with audio fx.
